### PR TITLE
license text moved also to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,23 @@
 
 This repository contains example datasets for the Mastodon cell-tracking plugin.
 
-## tgmm-mini
-
-This was created from the example dataset released with the TGMM software (https://www.janelia.org/lab/keller-lab/software/fast-accurate-reconstruction-cell-lineages-large-scale-fluorescence).
+## Dataset: tgmm-mini
+### Origin
+This dataset was created from the example dataset released with the TGMM software
+(https://www.janelia.org/lab/keller-lab/software/fast-accurate-reconstruction-cell-lineages-large-scale-fluorescence).
 
 The image data was converted from TIFs into BigDataViewer HDF5/XML.
 The tracks were imported from TGMMs XML output files into Mastodon.
 
+### License
+(see also [tgmm-mini/LICENSE.txt](tgmm-mini/LICENSE.txt))
+
+Janelia Open-Source Software
+Copyright © 2018 Howard Hughes Medical Institute
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of HHMI nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
motivated by this communication between @stefanhahmann and myself:

```
Date: Thu, 21 Sep 2023 07:44:58 +0000
From: Stefan Hahmann <stefan.hahmann@tu-dresden.de>
To: Vladimir Ulman <ulman@fi.muni.cz>
Subject: RE: Mastodon Demo Data
----------------------------------------
FYI. I just found out that in fact there is license attached to the date:
https://github.com/mastodon-sc/mastodon-example-data/blob/master/tgmm-mini/L
ICENSE.txt

Stefan.

-----Original Message-----
From: Vladimír Ulman <ulman@fi.muni.cz> 
Sent: Wednesday, September 13, 2023 5:08 PM
To: Hahmann, Stefan <stefan.hahmann@tu-dresden.de>
Subject: Re: Mastodon Demo Data

Hi Stefan,

I'm using this one:
https://github.com/mastodon-sc/mastodon-example-data

But there's no license attached to it :(
Maybe another thing to be resolved..

Cheers,
Vlado
```

And since the first sentence of the README says "...example dataset**s**", I'm proposing a structure
- Dataset: name
  - Origin (of the data)
  - License (to the data)
  
- Dataset: name of another dataset...
  - ...the pattern repeats...